### PR TITLE
docs: pin compatible fla-core version

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,15 @@ To use the Kimi Linear model, we recommend the following:
 
 * Language: `python` >= 3.10
 * Package: `torch` >= 2.6
-* Package: `fla-core` >= 0.4.0
+* Package: `fla-core` == 0.4.0
 
 ```shell
-pip install -U fla-core
+pip install "fla-core==0.4.0"
 ```
+
+The model's current remote implementation uses the KDA gate API from
+`fla-core==0.4.0`. Versions 0.4.1 and newer changed that API, so upgrading
+`fla-core` currently causes inference to fail during the gate call.
 
 Example Code:
 ```py


### PR DESCRIPTION
Fixes #10.

The README currently installs the latest `fla-core`, but Kimi-Linear's remote model code uses the KDA gate API from 0.4.0. Releases 0.4.1 through 0.5.1 changed that call to a `dt_bias`-based signature, so following the documented install command can leave inference broken.

This pins the example and requirements to `fla-core==0.4.0` and notes why the pin is necessary. I compared the remote model implementation with the relevant API signatures across 0.4.0–0.5.1 and checked that the updated command resolves the intended version.

This is only a compatibility correction to the installation docs; it does not add support for the newer API.
